### PR TITLE
Unable to Delete Characters from Database

### DIFF
--- a/sql/triggers.sql
+++ b/sql/triggers.sql
@@ -53,7 +53,6 @@ BEGIN
 	DELETE FROM `char_look`      WHERE `charid` = OLD.charid;
 	DELETE FROM `char_merit`     WHERE `charid` = OLD.charid;
 	DELETE FROM `char_pet`       WHERE `charid` = OLD.charid;
-	DELETE FROM `char_pet_name`  WHERE `charid` = OLD.charid;
 	DELETE FROM `char_points`    WHERE `charid` = OLD.charid;
 	DELETE FROM `char_profile`   WHERE `charid` = OLD.charid;
 	DELETE FROM `char_recast`    WHERE `charid` = OLD.charid;


### PR DESCRIPTION
char_pet_name no longer exists as a table but the DELETE command was still included in the TRIGGERS.sql file disabling auto deletion of characters through the game.

Removed the char_pet_name reference from file